### PR TITLE
Add clock delay parameter for emulated devices (e.g. HH-12INC)

### DIFF
--- a/AS5045.cpp
+++ b/AS5045.cpp
@@ -52,12 +52,13 @@
 
 #include "AS5045.h"
 
-AS5045::AS5045 (byte pinCS, byte pinCLK, byte pinDO, byte pinPROG) 
+AS5045::AS5045 (byte pinCS, byte pinCLK, byte pinDO, byte pinPROG, unsigned int clockDelay) 
 {
   _pinCS   = pinCS ;
   _pinCLK  = pinCLK ;
   _pinDO   = pinDO ;
   _pinPROG = pinPROG ;
+  _clockDelay = clockDelay;
 
   _status  = 0xFF ;  // invalid status
 }
@@ -184,6 +185,17 @@ boolean AS5045::init ()
   
 }
 
+void AS5045::clock_cycle ()
+{
+  if (_clockDelay == 0)
+    return;
+
+  digitalWrite (_pinCLK, LOW) ;
+  delayMicroseconds (_clockDelay) ;
+  digitalWrite (_pinCLK, HIGH) ;
+  delayMicroseconds (_clockDelay) ;
+}
+
 // read position value, squirrel away status
 unsigned int AS5045::read ()
 {
@@ -191,15 +203,13 @@ unsigned int AS5045::read ()
   unsigned int value = 0 ;
   for (byte i = 0 ; i < 12 ; i++)
   {
-    digitalWrite (_pinCLK, LOW) ;
-    digitalWrite (_pinCLK, HIGH) ;
+    clock_cycle () ;
     value = (value << 1) | digitalRead (_pinDO) ;
   }
   byte status = 0 ;
   for (byte i = 0 ; i < 6 ; i++)
   {
-    digitalWrite (_pinCLK, LOW) ;
-    digitalWrite (_pinCLK, HIGH) ;
+    clock_cycle () ;
     status = (status << 1) | digitalRead (_pinDO) ;
   }
   digitalWrite (_pinCS, HIGH) ;

--- a/AS5045.h
+++ b/AS5045.h
@@ -68,7 +68,7 @@
 class AS5045
 {
  public:
-  AS5045 (byte pinCS, byte pinCLK, byte pinDO, byte pinPROG = 0xFF) ;
+  AS5045 (byte pinCS, byte pinCLK, byte pinDO, byte pinPROG = 0xFF, unsigned int clockDelay = 0) ;
 
   boolean begin () ;
   boolean begin (int mag_offset) ;
@@ -88,11 +88,13 @@ class AS5045
   byte _pinCS ;
   byte _pinDO ;
   byte _pinPROG ;
+  unsigned int _clockDelay;
 
   byte _status ;
   byte _parity ;
 
   byte even_parity (byte val) ;
+  void clock_cycle (void);
   
   int _mag_offset;
   


### PR DESCRIPTION
This patch adds a clock delay parameter (_clockDelay) to the constructor,
which indicates the desired delay in microseconds between clock cycles
when reading the sensor device.

This is required for the HH-12INC inclinometer by DF1SR and SQ6EDU.

According to VK5DJ, this inclinometer emulates an AS5045 via an ARM STM32F,
and needs a slower clock rate (https://www.vk5dj.com/page63.html).

I've found that a value of 30us works for my setup.

Example use:

  static AS5045 my_as5405(CS_pin, CLK_pin, DO_pin, 0xFF, 30);

The default value is zero.

Signed-off-by: James Morris W7TXT <jmorris@namei.org>